### PR TITLE
Move calibration and tube season buttons

### DIFF
--- a/custom/src/BackendController.cpp
+++ b/custom/src/BackendController.cpp
@@ -339,7 +339,7 @@ void BackendController::processTelemetryUpdates()
 
                             if(!calMsgSent_)
                             {
-                                str_flight_status += "Waiting for user to calibrate panel. ";
+                                str_flight_status += "Waiting for user to calibrate detector. ";
                             }
 
                             if(!str_flight_status.isEmpty())
@@ -378,7 +378,7 @@ void BackendController::processTelemetryUpdates()
 
                         if(!calMsgSent_)
                         {
-                            str_flight_status += "Waiting for user to calibrate panel. ";
+                            str_flight_status += "Waiting for user to calibrate detector. ";
                         }
 
                         if(!str_flight_status.isEmpty())
@@ -571,7 +571,7 @@ void BackendController::processTelemetryUpdates()
     {
         if((this->subscribed_map_[SYSID_DETECTOR_COMP] || this->subscribed_map_[SYSID_EMITTER_COMP]) && !this->calMsgSent_ && (!this->targMsgSent_) )
         {
-            this->setFlightStatus("Waiting for user to send target information to UAVs. \n Waiting for user to calibrate panel.");
+            this->setFlightStatus("Waiting for user to send target information to UAVs. \n Waiting for user to calibrate detector.");
         }
     }
 
@@ -933,24 +933,15 @@ void BackendController::killScan()
     this->sendStartScan(scan_state);
 }
 
-void BackendController::detCal()
+void BackendController::payloadCal()
 {
-    qDebug() << "Detector Calibration Button Pressed";
+    qDebug() << "Payload Calibration Button Pressed";
     scan_state_ = StartScan::scan_cal;
     uint8_t scan_state = static_cast<uint8_t>(StartScan::scan_cal);
     this->sendStartScan(scan_state);
     // this->calMsgSent_ = true;
     // this->uav_state_updated_.store(true);
 }
-
-// void BackendController::detResetCal()
-// {
-//     qDebug() << "Detector Reset Calibration Button Pressed";
-//     scan_state_ = StartScan::scan_reset_cal;
-//     uint8_t scan_state = static_cast<uint8_t>(StartScan::scan_reset_cal);
-//     this->sendStartScan(scan_state);
-
-// }
 
 //payload
 void BackendController::setCadence(const uint32_t telemCadence)

--- a/custom/src/BackendController.h
+++ b/custom/src/BackendController.h
@@ -296,8 +296,7 @@ public:
     Q_INVOKABLE void stopScan();
     Q_INVOKABLE void killScan();
     Q_INVOKABLE void emTubeSeasoning();
-    Q_INVOKABLE void detCal();
-    // Q_INVOKABLE void detResetCal();
+    Q_INVOKABLE void payloadCal();
     void send_ack(AckType type);
 
     //payload settings

--- a/custom/src/FlyViewCustomLayer.qml
+++ b/custom/src/FlyViewCustomLayer.qml
@@ -598,13 +598,6 @@ Item {
                 QGCLabel { text: "Temperature (C): " + backend.EmTemp }
                 QGCLabel { text: "FIL current (mA): " + backend.FILCurrent }
                 QGCLabel { text: "BAT voltage (mV): " + backend.BATVoltage }
-
-                Button {
-                        Layout.fillWidth: true
-                        text: "Tube Seasoning"
-                        onClicked: backend.emTubeSeasoning()
-                }
-
             }
 
         }
@@ -667,18 +660,6 @@ Item {
                 QGCLabel { text: "Integration Time (ms): " + backend.detInt }
 
                 QGCLabel { text: "Detector Status: " + backend.detStatus }
-
-                Button {
-                    Layout.fillWidth: true
-                    text: "Calibrate Detector"
-                    onClicked: backend.detCal()
-                }
-
-                /*Button {
-                    Layout.fillWidth: true
-                    text: "Reset Calibration"
-                    onClicked: backend.detResetCal()
-                }*/
             }
         }
     }
@@ -728,6 +709,22 @@ Item {
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                 }*/
+            }
+
+            QGCButton {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+                font.pixelSize: ScreenTools.defaultFontPixelHeight * 0.9
+                text: "Calibrate Payloads"
+                onClicked: backend.payloadCal()
+            }
+
+            QGCButton {
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignHCenter
+                    font.pixelSize: ScreenTools.defaultFontPixelHeight * 0.9
+                    text: "Tube Seasoning"
+                    onClicked: backend.emTubeSeasoning()
             }
 
             QGCButton {


### PR DESCRIPTION
## Description

Moves calibrate and tube season buttons to main menu.
Unifies naming from "panel" to detector.
Removes stale code.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots

<img width="247" height="653" alt="image" src="https://github.com/user-attachments/assets/792fa293-932e-4dd4-9cf7-3fce01542549" />


## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues

Closes #3 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
