### PR TITLE
My circle undefined

### DIFF
--- a/custom/qml/QGroundControl/FlyView/FlyView.qml
+++ b/custom/qml/QGroundControl/FlyView/FlyView.qml
@@ -230,7 +230,6 @@ Item {
             onMapDoubleClicked: (position) => {
                 const coord = toCoordinate(position, false)
                 backend.setCenterCoordinate(coord)
-                myCircle.center = coord
                 followGps = false
                 console.log("Double-click moved circle to", coord.latitude, coord.longitude)
             }


### PR DESCRIPTION
## Description
Fixes `   141.703 Warning: qrc:/Custom/qml/QGroundControl/FlyView/FlyView.qml:233: ReferenceError: myCircle is not defined - default - (unknown:233)` when you double click to set the map location.


## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
