### PR TITLE
block start mission till prearm pass

### DIFF
--- a/custom/src/FlyViewCustomLayer.qml
+++ b/custom/src/FlyViewCustomLayer.qml
@@ -20,7 +20,6 @@ Item {
 
     property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     property var    _multiVehicleManager:   QGroundControl.multiVehicleManager
-    property var    _vehicles:              _multiVehicleManager.vehicles
     property real   _indicatorDiameter:     ScreenTools.defaultFontPixelWidth * 18
     property real   _indicatorsHeight:      ScreenTools.defaultFontPixelHeight
     property var    _sepColor:              qgcPal.globalTheme === QGCPalette.Light ? Qt.rgba(0,0,0,0.5) : Qt.rgba(1,1,1,0.5)
@@ -33,6 +32,13 @@ Item {
     property string _messageTitle:          ""
     property string _messageText:           ""
     property real   _toolsMargin:           ScreenTools.defaultFontPixelWidth * 0.75
+    property var _vehicleDetector: QGroundControl.multiVehicleManager.vehicles.count > 0
+        ? QGroundControl.multiVehicleManager.getVehicleById(1)
+        : null
+
+    property var _vehicleEmitter:  QGroundControl.multiVehicleManager.vehicles.count > 0
+        ? QGroundControl.multiVehicleManager.getVehicleById(2)
+        : null
 
     function secondsToHHMMSS(timeS) {
         var sec_num = parseInt(timeS, 10);
@@ -717,14 +723,16 @@ Item {
                 font.pixelSize: ScreenTools.defaultFontPixelHeight * 0.9
                 text: "Calibrate Payloads"
                 onClicked: backend.payloadCal()
+                enabled: _vehicleDetector && _vehicleEmitter && !_vehicleDetector.flying && !_vehicleEmitter.flying
             }
 
             QGCButton {
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignHCenter
-                    font.pixelSize: ScreenTools.defaultFontPixelHeight * 0.9
-                    text: "Tube Seasoning"
-                    onClicked: backend.emTubeSeasoning()
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+                font.pixelSize: ScreenTools.defaultFontPixelHeight * 0.9
+                text: "Tube Seasoning"
+                onClicked: backend.emTubeSeasoning()
+                enabled: _vehicleEmitter && !_vehicleEmitter.flying
             }
 
             QGCButton {
@@ -877,7 +885,7 @@ Item {
                 font.pixelSize: ScreenTools.defaultFontPixelHeight * 0.9
                 text: "Send Goal"
                 onClicked: backend.sendGoal()
-                enabled: backend.isSendGoalButtonEn
+                enabled: backend.isSendGoalButtonEn && _vehicleEmitter && _vehicleDetector
             }
 
             QGCButton {

--- a/custom/src/FlyViewCustomLayer.qml
+++ b/custom/src/FlyViewCustomLayer.qml
@@ -35,10 +35,21 @@ Item {
     property var _vehicleDetector: QGroundControl.multiVehicleManager.vehicles.count > 0
         ? QGroundControl.multiVehicleManager.getVehicleById(1)
         : null
-
     property var _vehicleEmitter:  QGroundControl.multiVehicleManager.vehicles.count > 0
         ? QGroundControl.multiVehicleManager.getVehicleById(2)
         : null
+    property bool _detectorCanArm: _vehicleDetector
+        ? (_vehicleDetector.healthAndArmingCheckReport.supported
+            ? _vehicleDetector.healthAndArmingCheckReport.canArm
+            : !_vehicleDetector.prearmError)
+        : false
+
+    property bool _emitterCanArm: _vehicleEmitter
+        ? (_vehicleEmitter.healthAndArmingCheckReport.supported
+            ? _vehicleEmitter.healthAndArmingCheckReport.canArm
+            : !_vehicleEmitter.prearmError)
+        : false
+    property bool _vehiclesReadyForMission: _detectorCanArm && _emitterCanArm
 
     function secondsToHHMMSS(timeS) {
         var sec_num = parseInt(timeS, 10);
@@ -905,7 +916,7 @@ Item {
                 font.pixelSize: ScreenTools.defaultFontPixelHeight * 0.9
                 text: "Start Mission"
                 onClicked: backend.startMission()
-                enabled: backend.isStartMissionButtonEn
+                enabled: backend.isStartMissionButtonEn && _vehiclesReadyForMission
             }
 
             QGCButton {


### PR DESCRIPTION
## Description

Prevent an operator from trying to start the mission till prearm checks pass

Limitation: The status bar (backend) knows you are ready to start, but the frontend knows more.
We are mixing frontend/backend logic and this will need cleaned up to be clearer.

Tested by setting SIM_GPS1_FIXTYPE 0 on one drone and observing prearm failure and the start missoin button go gray.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

Needs testing with PX4 SITL

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
Closes #5 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
