### PR TITLE
Hotfix missing circles around emitter

### DIFF
--- a/custom/qml/QGroundControl/FlyView/FlyView.qml
+++ b/custom/qml/QGroundControl/FlyView/FlyView.qml
@@ -91,19 +91,19 @@ Item {
                 border.width: 2
                 border.color: "#00FF00"
             }
-
+                
             MapCircle {
-                center: mapControl._vehicleEmitter ? mapControl._vehicleEmitter.coordinate : QtPositioning.coordinate()
+                visible: _vehicleEmitter !== null
+                center: backend.emitterCurrentPos
                 radius: 30
-                //color: "#4000FF00"
                 border.width: 2
                 border.color: "#e1ff00"
             }
 
             MapCircle {
-                center: mapControl._vehicleEmitter ? mapControl._vehicleEmitter.coordinate : QtPositioning.coordinate()
+                visible: _vehicleEmitter !== null
+                center: backend.emitterCurrentPos
                 radius: 50
-                //color: "#4000FF00"
                 border.width: 2
                 border.color: "#00FF00"
             }
@@ -176,55 +176,6 @@ Item {
                     }
                 }
             }
-
-        
-            // --- Emitter  Position ---
-            MapQuickItem {
-                id: emitterPosition
-                objectName: "emitterPosition"
-                visible: mapControl._vehicleEmitter !== null
-                coordinate: mapControl._vehicleEmitter ? mapControl._vehicleEmitter.coordinate : QtPositioning.coordinate()
-                anchorPoint.x: 10
-                anchorPoint.y: 10
-                sourceItem: Rectangle {
-                    width: 20
-                    height: 20
-                    color: "blue"
-                    radius: width / 2
-
-                    Text {
-                        anchors.centerIn: parent
-                        text: "EP"
-                        color: "white"
-                        font.bold: true
-                        font.pixelSize: 16
-                    }
-                }
-            }
-
-            // --- Detector  Position ---
-            MapQuickItem {
-                id: detectorPosition
-                objectName: "detectorPosition"
-                visible: mapControl._vehicleDetector !== null
-                coordinate: mapControl._vehicleDetector ? mapControl._vehicleDetector.coordinate : QtPositioning.coordinate()
-                anchorPoint.x: 10
-                anchorPoint.y: 10
-                sourceItem: Rectangle {
-                    width: 20
-                    height: 20
-                    color: "blue"
-                    radius: width / 2
-
-                    Text {
-                        anchors.centerIn: parent
-                        text: "DP"
-                        color: "white"
-                        font.bold: true
-                        font.pixelSize: 16
-                    }
-                }
-            }
         
             //Double click for circle
             onMapDoubleClicked: (position) => {
@@ -232,10 +183,7 @@ Item {
                 backend.setCenterCoordinate(coord)
                 followGps = false
                 console.log("Double-click moved circle to", coord.latitude, coord.longitude)
-            }
-        
-        
-        
+            }        
         }
 
         FlyViewVideo {


### PR DESCRIPTION
## Description
Emitter circles didn't show up because the emitter and detector drone properties were no longer register.

getVehicleById is Q_INVOKABLE not a Q_PROPERTY

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
