### PR TITLE
Added Left/Right/Fwd/Back nudge

### DIFF
--- a/custom/custom.qrc
+++ b/custom/custom.qrc
@@ -24,6 +24,7 @@
         <file alias="QGroundControl/FlightMap/FlightMap.qml">qml/QGroundControl/FlightMap/FlightMap.qml</file>
         <file alias="QGroundControl/FlyView/CustomGuidedActionsController.qml">src/CustomGuidedActionsController.qml</file>
         <file alias="QGroundControl/FlyView/FlyViewCustomLayer.qml">src/FlyViewCustomLayer.qml</file>
+        <file alias="QGroundControl/FlyView/FlyViewToolStripActionList.qml">src/FlyViewToolStripActionList.qml</file>
     </qresource>
     <qresource prefix="/Custom/res">
         <file alias="QGCLogoFull.svg">res/Images/QGCLogoFull.svg</file>

--- a/custom/src/BackendController.cpp
+++ b/custom/src/BackendController.cpp
@@ -1211,3 +1211,19 @@ void BackendController::setFlightStatus(const QString flightstatus)
         emit flightStatusChanged();
     }
 }
+
+void BackendController::setNudgeMode(const uint8_t nudgeMode)
+{
+    if(this->nudge_mode_ != nudgeMode)
+    {
+        this->nudge_mode_ = nudgeMode;
+        emit nudgeModeChanged(this->nudge_mode_);
+    }
+
+}
+
+void  BackendController::toggleNudgeMode()
+{
+    qDebug() << "Toggle Nudge Mode Pressed";
+    setNudgeMode(this->nudge_mode_ == 0 ? 1 : 0);
+}

--- a/custom/src/BackendController.h
+++ b/custom/src/BackendController.h
@@ -115,7 +115,6 @@ class BackendController : public QObject {
     Q_PROPERTY(bool isSendGoalButtonEn READ isSendGoalButtonEn WRITE setSendGoalButtonEn NOTIFY sendGoalButtonChanged);
     Q_PROPERTY(bool isEndMissionButtonEn READ isEndMissionButtonEn WRITE setEndMissionButtonEn NOTIFY endMissionButtonChanged);
 
-
     Q_PROPERTY(int32_t detectorXrayWindow READ detectorXrayWindow WRITE setXrayWindow NOTIFY xrayWindowChanged)
     Q_PROPERTY(QString fileName READ fileName WRITE setFileName NOTIFY fileNameChanged)
     Q_PROPERTY(uint8_t numImages READ numImages WRITE setNumImages NOTIFY numImagesChanged)
@@ -139,6 +138,8 @@ class BackendController : public QObject {
     Q_PROPERTY(QString detStatus READ detStatus NOTIFY detStatusChanged)
 
     Q_PROPERTY(QString flightStatus READ flightStatus WRITE setFlightStatus NOTIFY flightStatusChanged)
+
+    Q_PROPERTY(uint8_t nudgeMode READ nudgeMode WRITE setNudgeMode NOTIFY nudgeModeChanged)
 
 
 public:
@@ -276,6 +277,8 @@ public:
     uint8_t detBatPerc() const {return this->det_battery_charge_; }
 
     QString flightStatus() const {return this->flight_status_; }
+
+    uint8_t nudgeMode() const {return this->nudge_mode_; }
     
     //enable/disable buttons
     Q_INVOKABLE void setStartMissionButtonEn(const bool enabled);
@@ -323,6 +326,9 @@ public:
     Q_INVOKABLE void setDetectorConnected(const bool detectorConn);
 
     Q_INVOKABLE void setFlightStatus(const QString flightstatus);
+
+    Q_INVOKABLE void setNudgeMode(const uint8_t nudgeMode);
+    Q_INVOKABLE void toggleNudgeMode();
 
 signals:
     void scanMissionModeChanged();
@@ -387,6 +393,8 @@ signals:
     void detStatusChanged();
 
     void flightStatusChanged();
+    void nudgeModeChanged(uint8_t nudgeMode);
+
 private slots:
     void _mavlinkMessageReceived(LinkInterface* link, mavlink_message_t message);
     void _vehicleAdded(Vehicle* vehicle);
@@ -398,9 +406,6 @@ private:
     void sendStartScan(StartScan state);
     void send_ack(AckType type, uint8_t src_id);
 
-
-
-    // sd::unique_ptr<DroneControl> ctrl;
     QGeoCoordinate center_coordinate_ {40.0156293, -105.2207272};
     double sep_distance_ { 10.0 };
     double bearing_ { 0.0 };
@@ -440,6 +445,7 @@ private:
     QString  det_status_ {};
     QString  file_name_ {"image"};
     uint8_t  num_images_{1};
+    uint8_t  nudge_mode_ {0};
 
     //emitter settings
     uint32_t em_test_duration_ms_ {5000};

--- a/custom/src/FlyViewCustomLayer.qml
+++ b/custom/src/FlyViewCustomLayer.qml
@@ -52,6 +52,9 @@ Item {
         : false
     property bool _vehiclesReadyForMission: _detectorCanArm && _emitterCanArm
 
+    // Nudge mode: 0 = Absolute (N/E/S/W), 1 = Relative (Fwd/Back/L/R) vs active vehicle heading
+    property int nudgeMode: 0
+
     property var  _customSettings:  QGroundControl.corePlugin.customSettings
     property var _sepDistFact: _customSettings.separationDistance
     property var _bearingFact: _customSettings.bearing
@@ -677,6 +680,17 @@ Item {
                         this)
                 }
 
+                // Absolute mode: pass through.  Relative mode: offset by active vehicle heading.
+                function bearingFor(absoluteDeg) {
+                    console.log("nudge mode = ", backend.nudgeMode)
+                    if (backend.nudgeMode === 0) {
+                        return absoluteDeg
+                    }
+                    var hdg = _activeVehicle ? _activeVehicle.heading.rawValue : 0
+                    return (absoluteDeg + hdg) % 360
+                }
+
+
                 // NORTH
                 Item {
                     Layout.row: 0; Layout.column: 1
@@ -696,8 +710,13 @@ Item {
                             c.stroke()
                         }
                     }
-                    Text { anchors.centerIn: parent; text: "N"; font.bold: true }
-                    MouseArea { anchors.fill: parent; onClicked: backend.nudge(0, parseFloat(nudgeInput.text)) }
+
+                    Text { 
+                        anchors.centerIn: parent
+                        text: backend.nudgeMode === 0 ? "N" : "F"
+                        font.bold: true 
+                    }
+                    MouseArea { anchors.fill: parent; onClicked: backend.nudge(parent.parent.bearingFor(0), parseFloat(nudgeInput.text)) }
                 }
 
                 // WEST
@@ -719,8 +738,12 @@ Item {
                             c.stroke()
                         }
                     }
-                    Text { anchors.centerIn: parent; text: "W"; font.bold: true }
-                    MouseArea { anchors.fill: parent; onClicked: backend.nudge(270, parseFloat(nudgeInput.text)) }
+                    Text { 
+                        anchors.centerIn: parent
+                        text: backend.nudgeMode === 0 ? "W" : "L"
+                        font.bold: true 
+                    }
+                    MouseArea { anchors.fill: parent; onClicked: backend.nudge(parent.parent.bearingFor(270), parseFloat(nudgeInput.text)) }
                 }
 
                 // CENTER
@@ -756,8 +779,11 @@ Item {
                             c.stroke()
                         }
                     }
-                    Text { anchors.centerIn: parent; text: "E"; font.bold: true }
-                    MouseArea { anchors.fill: parent; onClicked: backend.nudge(90, parseFloat(nudgeInput.text)) }
+                    Text { 
+                        anchors.centerIn: parent
+                        text: backend.nudgeMode === 0 ? "E" : "R"
+                        font.bold: true }
+                    MouseArea { anchors.fill: parent; onClicked: backend.nudge(parent.parent.bearingFor(90), parseFloat(nudgeInput.text)) }
                 }
 
                 // SOUTH
@@ -779,8 +805,12 @@ Item {
                             c.stroke()
                         }
                     }
-                    Text { anchors.centerIn: parent; text: "S"; font.bold: true }
-                    MouseArea { anchors.fill: parent; onClicked: backend.nudge(180, parseFloat(nudgeInput.text)) }
+                    Text { 
+                        anchors.centerIn: parent
+                        text: backend.nudgeMode === 0 ? "S" : "B"
+                        font.bold: true
+                    }
+                    MouseArea { anchors.fill: parent; onClicked: backend.nudge(parent.parent.bearingFor(180), parseFloat(nudgeInput.text)) }
                 }
             }   
             // ================= MISSION BUTTONS =================

--- a/custom/src/FlyViewToolStripActionList.qml
+++ b/custom/src/FlyViewToolStripActionList.qml
@@ -14,6 +14,14 @@ ToolStripActionList {
         GuidedActionLand { },
         GuidedActionRTL { },
         GuidedActionPause { },
-        FlyViewAdditionalActionsButton { }
+        FlyViewAdditionalActionsButton { },
+
+        ToolStripAction {
+            text:       backend.nudgeMode === 0 ? qsTr("Nudge\nAbs") : qsTr("Nudge\nRel")
+            iconSource: "/res/gear-white.svg"
+            visible:    true
+            enabled:    true
+            onTriggered: backend.toggleNudgeMode()
+        }
     ]
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->
I added a toggle button to the toolstrip to switch between North/East/South/West Nudge and Fwd/Back/Left/Right. The nudge for relative to UAV is always for the active vehicle in QGC. 
## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ X] Tested locally
- [ ] Added/updated unit tests
- [ X] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ X] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [X ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
